### PR TITLE
本番環境のタイムゾーンの問題でURLが09/26になってしまったため、日付を変更

### DIFF
--- a/source/_posts/2017/09/26/hello-hexo-netlify.md
+++ b/source/_posts/2017/09/26/hello-hexo-netlify.md
@@ -1,6 +1,6 @@
 ---
 title: ブログをHexoで作り直してNetlifyにデプロイした
-date: 2017-09-27 01:09:44
+date: 2017-09-26 23:59:59
 categories:
   - 技術
 tags:


### PR DESCRIPTION
`2017-09-27 01:09:44 +0900`に公開した記事のURLが09/26になってしまいました。
環境変数`TZ=Asia/Tokyo`を設定すると意図通りになるが、記事のURLが変わってしまいます。

hello-hexo-netlifyには既にはてブやスターがついているため、記事の日付を09/26にして解決することにします。
過去記事についてはWordPress時代なので問題ありません（Hexoに切り替えたときから今までのURLが間違っていたことになる）

ref: https://github.com/shimoju/shimoju.org/issues/4