### PR TITLE
hexo publishするときに上書きされてしまうのでcategoriesは指定しない

### DIFF
--- a/scaffolds/post.md
+++ b/scaffolds/post.md
@@ -2,6 +2,5 @@
 title: {{ title }}
 date: {{ date }}
 categories:
-  - 日記
 tags:
 ---


### PR DESCRIPTION
`hexo new draft`からの`hexo publish`するときにカテゴリーが上書きされてしまうのでpostでは指定しないようにしました。