### PR TITLE
サイトマップを生成する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,6 +86,11 @@ feed:
   path: feed.xml
   limit: 20
 
+# Sitemap
+## Docs: https://github.com/hexojs/hexo-generator-sitemap
+sitemap:
+  path: sitemap.xml
+
 # Markdown
 ## Docs: https://github.com/hexojs/hexo-renderer-marked
 marked:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1792,6 +1792,16 @@
         "object-assign": "4.1.1"
       }
     },
+    "hexo-generator-sitemap": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hexo-generator-sitemap/-/hexo-generator-sitemap-1.2.0.tgz",
+      "integrity": "sha1-MBj419Hi5Cs/caZacxb/z1g7w/M=",
+      "requires": {
+        "minimatch": "3.0.4",
+        "nunjucks": "2.5.2",
+        "object-assign": "4.1.1"
+      }
+    },
     "hexo-generator-tag": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/hexo-generator-tag/-/hexo-generator-tag-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "hexo-generator-category": "^0.1.3",
     "hexo-generator-feed": "^1.2.2",
     "hexo-generator-index": "^0.2.0",
+    "hexo-generator-sitemap": "^1.2.0",
     "hexo-generator-tag": "^0.2.0",
     "hexo-renderer-ejs": "^0.3.0",
     "hexo-renderer-marked": "^0.3.2",


### PR DESCRIPTION
そういえばWordPressじゃなくなってからサイトマップ消えてたなと思ったので生成するようにした。

https://github.com/hexojs/hexo-generator-sitemap

テンプレートをカスタマイズできるようだけど、とりあえずデフォルトで…

### デプロイ後

- [ ] sitemap.xmlを確認
- [ ] Search Consoleからサイトマップを登録
  